### PR TITLE
145 courses containing non ascii chars results in 404

### DIFF
--- a/src/app/courses/[code]/layout.tsx
+++ b/src/app/courses/[code]/layout.tsx
@@ -21,8 +21,10 @@ export default async function CourseLayout({
     notFound();
   }
 
+  const decodedCode = decodeURIComponent(code);
+
   const course = await prisma.course.findUnique({
-    where: { code: params.code },
+    where: { code: decodedCode },
     include: { grades: true },
   });
 

--- a/src/app/courses/[code]/page.tsx
+++ b/src/app/courses/[code]/page.tsx
@@ -24,8 +24,9 @@ interface CourseProps {
 
 export async function generateMetadata({ params }: CourseProps) {
   const { code } = params;
+  const decodedCode = decodeURIComponent(code);
 
-  const course = await getCourse(code);
+  const course = await getCourse(decodedCode);
 
   if (!course || !course.hasGrades) {
     notFound();
@@ -64,8 +65,9 @@ export async function generateStaticParams() {
 
 export default async function Course({ params }: CourseProps) {
   const { code } = params;
+  const decodedCode = decodeURIComponent(code);
 
-  const course = await getCourse(code);
+  const course = await getCourse(decodedCode);
 
   if (!course || !course.hasGrades) {
     notFound();


### PR DESCRIPTION
Course codes in path params are now decoded so they can contain non ascii chars.

Closes #145 